### PR TITLE
Small cleanup of the demo

### DIFF
--- a/rollup.demo.config.js
+++ b/rollup.demo.config.js
@@ -16,8 +16,8 @@ const demoSourceCodePlugin = {
         id.length - SOURCE_SUFFIX.length
       );
       let source = await fs.readFile(fileId, "utf8");
-      source = source.replace(/^[\s\S]*(async function animation)/, '$1').replace(/ $/, '');
-      source = source.replace(/<\/script>[\s\S]*$/, '').replace(/ $/, '');
+      source = source.replace(/^[\s\S]*(async function animation)/, '$1');
+      source = source.replace(/<\/script>[\s\S]*$/, '');
       return `export default ${JSON.stringify(source)};`;
     }
     return null;

--- a/src/demo/demo.svelte
+++ b/src/demo/demo.svelte
@@ -1,11 +1,13 @@
 <script>
   import Sidebar from "./sidebar";
   import { DEMOS } from "./samples";
-  let activeDemo = DEMOS[0];
+  let activeDemo = DEMOS.find(demo => demo.type != "category");
 
   function fromHash() {
     let value = decodeURIComponent(window.location.hash.slice(1));
-    let demo = DEMOS.find(demo => demo.title === value);
+    let demo = DEMOS.find(
+      demo => demo.title === value && demo.type != "category"
+    );
     if (demo != null) {
       activeDemo = demo;
     } else {

--- a/src/samples/tsconfig.json
+++ b/src/samples/tsconfig.json
@@ -1,6 +1,0 @@
-{
-	"extends": "../../tsconfig",
-	"include": [
-		"./*.ts"
-	],
-}


### PR DESCRIPTION
- Preventing a category from being selected (through hash in URL).
- Activating the first demo by default (excluding categories)
- Removing useless calls to .replace() when processing the source code to display in the demo
- Removing useless tsconfig.json file in src/samples